### PR TITLE
Added vertex_attrib_pointer_u8

### DIFF
--- a/gl2.rs
+++ b/gl2.rs
@@ -619,6 +619,21 @@ pub fn vertex_attrib_pointer_f32(index: GLuint,
     }
 }
 
+pub fn vertex_attrib_pointer_u8(index: GLuint,
+                                 size: GLint,
+                                 normalized: bool,
+                                 stride: GLsizei,
+                                 offset: GLuint) {
+    unsafe {
+        ll::glVertexAttribPointer(index,
+                                  size,
+                                  UNSIGNED_BYTE,
+                                  normalized as GLboolean,
+                                  stride,
+                                  reinterpret_cast(&(offset as uint)));
+    }
+}
+
 pub fn viewport(x: GLint, y: GLint, width: GLsizei, height: GLsizei) {
     unsafe {
         ll::glViewport(x, y, width, height);


### PR DESCRIPTION
I really feel like this code shouldn't be duplicated and the type param should just be exposed. Then we'd just have one vertex_attrib_pointer and specify the type. Maybe that's not very Rustic though; your call. If you're up for it, I'll make it a seperate PR.
