### PR TITLE
Truncated null bytes from shader logs

### DIFF
--- a/gl2.rs
+++ b/gl2.rs
@@ -624,24 +624,26 @@ pub fn get_program_iv(program: GLuint, pname: GLenum) -> GLint {
 
 pub fn get_program_info_log(program: GLuint) -> ~str {
     unsafe {
-        let result = from_elem(1024u, 0u8);
+        let mut result = from_elem(1024u, 0u8);
         let result_len: GLsizei = 0 as GLsizei;
         ll::glGetProgramInfoLog(program,
                                1024 as GLsizei,
                                to_unsafe_ptr(&result_len),
                                to_ptr(result) as *GLchar);
+        result.truncate((result_len - 1)as uint);
         return from_bytes(result);
     }
 }
 
 pub fn get_shader_info_log(shader: GLuint) -> ~str {
     unsafe {
-        let result = from_elem(1024u, 0u8);
+        let mut result = from_elem(1024u, 0u8);
         let result_len: GLsizei = 0 as GLsizei;
         ll::glGetShaderInfoLog(shader,
                                1024 as GLsizei,
                                to_unsafe_ptr(&result_len),
                                to_ptr(result) as *GLchar);
+        result.truncate((result_len - 1)as uint);
         return from_bytes(result);
     }
 }

--- a/gl2.rs
+++ b/gl2.rs
@@ -622,6 +622,18 @@ pub fn get_program_iv(program: GLuint, pname: GLenum) -> GLint {
     }
 }
 
+pub fn get_program_info_log(program: GLuint) -> ~str {
+    unsafe {
+        let result = from_elem(1024u, 0u8);
+        let result_len: GLsizei = 0 as GLsizei;
+        ll::glGetProgramInfoLog(program,
+                               1024 as GLsizei,
+                               to_unsafe_ptr(&result_len),
+                               to_ptr(result) as *GLchar);
+        return from_bytes(result);
+    }
+}
+
 pub fn get_shader_info_log(shader: GLuint) -> ~str {
     unsafe {
         let result = from_elem(1024u, 0u8);


### PR DESCRIPTION
This commit depends on https://github.com/mozilla-servo/rust-opengles/pull/11 -- The output I was getting is as follows:

```
rust: ~"~\"Vertex shader(s) failed to link, fragment shader(s) failed to link.\\nERROR: error(#280) Not all shaders have valid object code\\nERROR: error(#280) Not all shaders have valid object code\\n\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
\\x00\\x00\\x00\\x00\\x00\\x00\\[...]
```

After the change, it becomes:

```
rust: ~"~\"Vertex shader(s) failed to link, fragment shader(s) failed to link.\\nERROR: error(#280) Not all shaders have valid object code\\nERROR: error(#280) Not all shaders have valid object code\\n\""
```
