### PR TITLE
Added glIs*

### DIFF
--- a/gl2.rs
+++ b/gl2.rs
@@ -682,6 +682,48 @@ pub fn get_uniform_location(program: GLuint, name: ~str) -> c_int {
     }
 }
 
+pub fn is_buffer(buffer: GLuint) -> GLboolean {
+  unsafe {
+    ll::glIsBuffer(buffer)
+  }
+}
+
+pub fn is_enabled(cap: GLenum) -> GLboolean {
+  unsafe {
+    ll::glIsEnabled(cap)
+  }
+}
+
+pub fn is_framebuffer(framebuffer: GLuint) -> GLboolean {
+  unsafe {
+    ll::glIsFramebuffer(framebuffer)
+  }
+}
+
+pub fn is_program(program: GLuint) -> GLboolean {
+  unsafe {
+    ll::glIsProgram(program)
+  }
+}
+
+pub fn is_renderbuffer(renderbuffer: GLuint) -> GLboolean {
+  unsafe {
+    ll::glIsRenderbuffer(renderbuffer)
+  }
+}
+
+pub fn is_shader(shader: GLuint) -> GLboolean {
+  unsafe {
+    ll::glIsShader(shader)
+  }
+}
+
+pub fn is_texture(texture: GLuint) -> GLboolean {
+  unsafe {
+    ll::glIsTexture(texture)
+  }
+}
+
 pub fn link_program(program: GLuint) {
     unsafe {
         return ll::glLinkProgram(program);

--- a/gl2.rs
+++ b/gl2.rs
@@ -696,45 +696,45 @@ pub fn get_uniform_location(program: GLuint, name: ~str) -> c_int {
     }
 }
 
-pub fn is_buffer(buffer: GLuint) -> GLboolean {
+pub fn is_buffer(buffer: GLuint) -> bool {
   unsafe {
-    ll::glIsBuffer(buffer)
+    ll::glIsBuffer(buffer) > 0
   }
 }
 
-pub fn is_enabled(cap: GLenum) -> GLboolean {
+pub fn is_enabled(cap: GLenum) -> bool {
   unsafe {
-    ll::glIsEnabled(cap)
+    ll::glIsEnabled(cap) > 0
   }
 }
 
-pub fn is_framebuffer(framebuffer: GLuint) -> GLboolean {
+pub fn is_framebuffer(framebuffer: GLuint) -> bool {
   unsafe {
-    ll::glIsFramebuffer(framebuffer)
+    ll::glIsFramebuffer(framebuffer) > 0
   }
 }
 
-pub fn is_program(program: GLuint) -> GLboolean {
+pub fn is_program(program: GLuint) -> bool {
   unsafe {
-    ll::glIsProgram(program)
+    ll::glIsProgram(program) > 0
   }
 }
 
-pub fn is_renderbuffer(renderbuffer: GLuint) -> GLboolean {
+pub fn is_renderbuffer(renderbuffer: GLuint) -> bool {
   unsafe {
-    ll::glIsRenderbuffer(renderbuffer)
+    ll::glIsRenderbuffer(renderbuffer) > 0
   }
 }
 
-pub fn is_shader(shader: GLuint) -> GLboolean {
+pub fn is_shader(shader: GLuint) -> bool {
   unsafe {
-    ll::glIsShader(shader)
+    ll::glIsShader(shader) > 0
   }
 }
 
-pub fn is_texture(texture: GLuint) -> GLboolean {
+pub fn is_texture(texture: GLuint) -> bool {
   unsafe {
-    ll::glIsTexture(texture)
+    ll::glIsTexture(texture) > 0
   }
 }
 


### PR DESCRIPTION
They're currently returning GLboolean, which is actually a u8. This is how the ll bindings expose them, so I kept it that way, but it'd be nice to just have them return Rust booleans. The current syntax looks something like:  

``` rust
if gl::is_buffer(name) > 0
{ ... }
```

and it'd just flow better as:

``` rust
if gl::is_buffer(name)
{ ... }
```

Let me know what you think.

Cheers,
Jeaye
