### PR TITLE
Add GLX_VENDOR define

### DIFF
--- a/glx.rs
+++ b/glx.rs
@@ -79,6 +79,8 @@ pub static GLX_AUX9_EXT: c_int        = 0x20eb;
 pub static GLX_DRAWABLE_TYPE: c_int   = 0x8010;
 pub static GLX_RENDER_TYPE: c_int     = 0x8011;
 
+pub static GLX_VENDOR: c_int          = 1;
+
 pub static GLX_RGBA: c_int            = 4;
 pub static GLX_DOUBLEBUFFER: c_int    = 5;
 pub static GLX_ALPHA_SIZE: c_int      = 11;


### PR DESCRIPTION
GLX_VENDOR is used with glXGetClientString.
Ref [PR#67](https://github.com/mozilla-servo/rust-layers/pull/67/files).
